### PR TITLE
ci: cancel superseded runs + restrict push builds to default branch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,10 @@
 name: Builds, tests & co
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions: read-all
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,6 +6,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Two CI fixes to relieve the org's shared GitHub-hosted runner pool (free plan, ~20 concurrent jobs across **all** repos), which was saturated with stacked/duplicate runs.

**1. Cancel superseded runs.** Adds a `concurrency` group so a new push to a PR cancels the still-running superseded run for that ref (scoped to `pull_request` events, so default-branch pushes/deploys are never cancelled):

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**2. Only run `push` builds on the default branch.** The `push:` trigger had no branch filter, so every push to a PR branch ran **twice** — once as `push`, once as `pull_request` — for the same commit. The concurrency group can't dedupe those (the two events fall into different group keys). Restricting `push:` to the default branch keeps deploys/merges covered while leaving PR validation to the `pull_request` event.
